### PR TITLE
Add autostart argument to Mercury. Also autostop on exit

### DIFF
--- a/iocBoot/iocMercuryiTC/st-level.cmd
+++ b/iocBoot/iocMercuryiTC/st-level.cmd
@@ -4,7 +4,7 @@
 stringiftest("LEVEL", "$(VI_LEVEL_$(LEVEL_NUM)=)")
 
 $(IFLEVEL) calc("PORT_NUM", "$(LEVEL_NUM)+4")
-$(IFLEVEL) lvDCOMConfigure("lvfp$(PORT_NUM)", "frontpanel_level", "${MERCURY_ITC}/data/lv_MercuryLevel.xml")
+$(IFLEVEL) lvDCOMConfigure("lvfp$(PORT_NUM)", "frontpanel_level", "${MERCURY_ITC}/data/lv_MercuryLevel.xml", "$(LVDCOM_HOST=)", $(LVDCOM_OPTIONS=6), "$(LVDCOM_PROGID=)", "$(LVDCOM_USER=)", "$(LVDCOM_PASS=)")
 
 ## Load our record instances
 $(IFLEVEL) dbLoadRecords("db/MercuryLevel.db", "P=$(MYPVPREFIX)$(IOCNAME):LEVEL:$(LEVEL_NUM):,port=lvfp$(PORT_NUM)")

--- a/iocBoot/iocMercuryiTC/st-temp.cmd
+++ b/iocBoot/iocMercuryiTC/st-temp.cmd
@@ -3,7 +3,7 @@
 
 stringiftest("TEMP", "$(VI_TEMP_$(TEMP_NUM)=)")
 
-$(IFTEMP) lvDCOMConfigure("lvfp$(TEMP_NUM)", "frontpanel_temp", "${MERCURY_ITC}/data/lv_MercuryTemp.xml")
+$(IFTEMP) lvDCOMConfigure("lvfp$(TEMP_NUM)", "frontpanel_temp", "${MERCURY_ITC}/data/lv_MercuryTemp.xml", "$(LVDCOM_HOST=)", $(LVDCOM_OPTIONS=6), "$(LVDCOM_PROGID=)", "$(LVDCOM_USER=)", "$(LVDCOM_PASS=)")
 
 ## Load our record instances
 $(IFTEMP) dbLoadRecords("db/MercuryTemp.db", "P=$(MYPVPREFIX)$(IOCNAME):$(TEMP_NUM):,port=lvfp$(TEMP_NUM)")


### PR DESCRIPTION
# Description

I've added the relevant flags to auto start the Mercury VIs when the IOC starts, and exit when the IOC stops

# Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3167

# Acceptance criteria

When the IOC is started, the VI should now start, rather than sitting idle. You should see a communication error appear for those cards you are using (assuming you don't actually have a Mercury) and no error for those cards you haven't specified.

Similarly, launch the IOC and launch some Mercury VIs. The VIs for the cards you have specified to use in the configuration should be active, those cards you're not using should be idle

![image](https://user-images.githubusercontent.com/10273443/39815702-d402029a-5390-11e8-99da-9fdf0bb63074.png)