### PR TITLE
Add Percent of Volt Limit to IOC

### DIFF
--- a/MercuryiTCApp/Db/MercuryPressure.db
+++ b/MercuryiTCApp/Db/MercuryPressure.db
@@ -380,6 +380,14 @@ record(ai, "$(P)HEATER:VOLT")
     field(SDIS, "$(P)DISABLE")
 }
 
+record(calc, "$(P)HEATER:VOLT_PRCNT")
+{
+    field(DESC, "% of voltage limit used")
+    field(INPA, "$(P)HEATER:VOLT CP MSS")
+    field(INPB, "$(P)HEATER:VOLT_LIMIT CP MSS")
+    field(CALC, "(A / B) * 100")
+}
+
 record(ai, "$(P)HEATER:CURR")
 {
     field(DESC, "Current on the heater")

--- a/MercuryiTCApp/Db/MercuryPressure.db
+++ b/MercuryiTCApp/Db/MercuryPressure.db
@@ -383,6 +383,8 @@ record(ai, "$(P)HEATER:VOLT")
 record(calc, "$(P)HEATER:VOLT_PRCNT")
 {
     field(DESC, "% of voltage limit used")
+    field(PREC, "3")
+    field(EGU,  "%")
     field(INPA, "$(P)HEATER:VOLT CP MSS")
     field(INPB, "$(P)HEATER:VOLT_LIMIT CP MSS")
     field(CALC, "B > 0 ? (A / B) * 100 : 0")

--- a/MercuryiTCApp/Db/MercuryPressure.db
+++ b/MercuryiTCApp/Db/MercuryPressure.db
@@ -385,7 +385,7 @@ record(calc, "$(P)HEATER:VOLT_PRCNT")
     field(DESC, "% of voltage limit used")
     field(INPA, "$(P)HEATER:VOLT CP MSS")
     field(INPB, "$(P)HEATER:VOLT_LIMIT CP MSS")
-    field(CALC, "(A / B) * 100")
+    field(CALC, "B > 0 ? (A / B) * 100 : 0")
 }
 
 record(ai, "$(P)HEATER:CURR")

--- a/MercuryiTCApp/Db/MercuryTemp.db
+++ b/MercuryiTCApp/Db/MercuryTemp.db
@@ -377,6 +377,8 @@ record(ai, "$(P)HEATER:VOLT")
 record(calc, "$(P)HEATER:VOLT_PRCNT")
 {
     field(DESC, "% of voltage limit used")
+    field(PREC, "3")
+    field(EGU,  "%")
     field(INPA, "$(P)HEATER:VOLT CP MSS")
     field(INPB, "$(P)HEATER:VOLT_LIMIT CP MSS")
     field(CALC, "B > 0 ? (A / B) * 100 : 0")

--- a/MercuryiTCApp/Db/MercuryTemp.db
+++ b/MercuryiTCApp/Db/MercuryTemp.db
@@ -374,6 +374,14 @@ record(ai, "$(P)HEATER:VOLT")
     field(SDIS, "$(P)DISABLE")
 }
 
+record(calc, "$(P)HEATER:VOLT_PRCNT")
+{
+    field(DESC, "% of voltage limit used")
+    field(INPA, "$(P)HEATER:VOLT CP MSS")
+    field(INPB, "$(P)HEATER:VOLT_LIMIT CP MSS")
+    field(CALC, "B > 0 ? (A / B) * 100 : 0")
+}
+
 record(ai, "$(P)HEATER:CURR")
 {
     field(DESC, "Current on the heater")


### PR DESCRIPTION
Added a calculation to the IOC to indicate how much of the volt limit is currently being used. Resets to 0% when a divide by 0 error would occur (such as before the limit is set).

Refs #ISISComputingGroup/IBEX#6283